### PR TITLE
Update headers.scss

### DIFF
--- a/app/assets/stylesheets/headers.scss
+++ b/app/assets/stylesheets/headers.scss
@@ -47,6 +47,10 @@
 
 .expands-footer-link {
   color: #dddddd;
+  a:hover, a:focus {
+    color: #dddddd;
+    text-decoration: underline;
+  }  
 }
 
 #search-box {


### PR DESCRIPTION
So the links in the footer don't disappear to dark gray when you click. 
Could also be done without underline but with a font-weight increase.